### PR TITLE
feat(aws): Lambda の並列性とコールドスタートを確かめる実験

### DIFF
--- a/infra/aws/lambda-concurrency/.gitignore
+++ b/infra/aws/lambda-concurrency/.gitignore
@@ -1,0 +1,5 @@
+dist/
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*

--- a/infra/aws/lambda-concurrency/README.md
+++ b/infra/aws/lambda-concurrency/README.md
@@ -1,0 +1,113 @@
+# Lambda の並列性の単位を確かめる
+
+関連: [実行環境の再利用とコールドスタート](./cold-start-and-reuse.md)（2 回目以降が速い理由・キャッシュの単位・SnapStart）
+
+## 確かめたかったこと
+
+Lambda は「I/O wait 中に同じ実行環境で別リクエストを処理する」のか、それとも
+「I/O wait 中でも 1 invocation が実行環境を占有し、並列化は execution environment
+の増加でしか起きない」のか。
+
+観測する軸は 2 つだけ。
+
+1. 同じ envId（実行環境）の中で inFlight が 2 以上になるか
+2. 各リクエストが 5 秒待つだけの処理を 10 並列で投げたとき、合計時間が約 5 秒か約 50 秒か
+
+## 結論
+
+デフォルトの Lambda では、**1 つの実行環境は 1 invocation を処理中に他のリクエストを
+受けない**。並列化は実行環境の増加でしか起きない。**Lambda Web Adapter を入れても
+この単位は変わらない**（複数リクエストの同時処理は Lambda Managed Instances という別の
+オプトイン機能の領分）。
+
+一次情報:
+
+- "During this entire process, this execution environment is busy and cannot
+  process other requests." — [Understanding Lambda function scaling](https://docs.aws.amazon.com/lambda/latest/dg/lambda-concurrency.html)
+- "For each concurrent request, Lambda provisions a separate instance of your
+  execution environment." — 同上
+- Web Adapter は「Lambda の invoke イベント → ローカル HTTP server への 1 リクエスト」
+  への変換ブリッジ。多重同時処理は "Lambda Managed Instances for multi-concurrent
+  request handling" の役割 — [aws-lambda-web-adapter](https://github.com/awslabs/aws-lambda-web-adapter)
+
+## 実測結果（ap-northeast-1 / nodejs22.x / 各リクエスト 5 秒 sleep / 10 並列）
+
+| ランナー | reserved concurrency | 合計時間 | 異なる envId 数 | 1 env 内の最大 inFlight |
+|---|---|---|---|---|
+| ローカル Node HTTP server | － | 5.04 s | 1 | 10 |
+| lambda-plain（普通の handler） | 1 | 52.38 s | 1 | 1 |
+| lambda-plain | 10 | 5.49 s | 10 | 1 |
+| lambda-lwa（Web Adapter + 同一 server） | 1 | 52.40 s | 1 | 1 |
+| lambda-lwa | 10 | 5.54 s | 10 | 1 |
+
+読み解き:
+
+- ローカルの普通の HTTP server は 1 プロセス（envId 1 個）で 10 リクエストを
+  I/O wait 中に多重処理する（maxInFlight=10）。だから合計 ~5 秒。
+- Lambda は concurrency=1 だと 1 つの実行環境が 10 回**直列**に処理する
+  （envId 1 個・maxInFlight=1・合計 ~50 秒）。I/O wait 中でも次を受けない。
+- Lambda は concurrency=10 だと実行環境が 10 個に増え、各 env が 1 リクエストずつ
+  処理する（envId 10 個・各 maxInFlight=1・合計 ~5 秒）。並列化の単位は実行環境。
+- **lambda-lwa は lambda-plain と同じ挙動**。ローカルと同一の `src/server.mjs` を
+  動かしているのに maxInFlight は 1 のまま。「Express を Lambda に載せたんだから
+  I/O wait 中に多重処理されるはず」という直感は成り立たない。
+
+補足: concurrency=10 の各 env は独立した microVM で、内部の Node プロセス PID は
+どの env でも同じ値になる（plain=2, lwa=5）。そのため PID は実行環境の識別子に
+ならない。モジュール初期化時に採番した UUID（`ENV_ID`）だけが実行環境ごとに一意。
+
+## 構成
+
+同一ロジック `work(sleepMs) = await sleep` を 3 ランナーで共有する。
+
+```
+src/shared.mjs   ENV_ID の採番と inFlight / maxInFlight / invocations の計測
+src/lambda.mjs   普通の async handler（lambda-plain、Function URL 背後）
+src/server.mjs   http server（ローカル基準 と lambda-lwa が同一ファイルを実行）
+src/run.sh       Web Adapter の起動コマンド（Handler = run.sh）
+driver/drive.mjs N 並列で叩き envId 単位で集計。throttle(429) はポーリング再試行
+infra/           terraform（2 関数 + Function URL + reserved concurrency 変数）
+build.sh         dist/plain.zip と dist/lwa.zip を生成（run.sh の実行ビットを保持）
+```
+
+lambda-lwa の要点（[公式サンプル](https://github.com/awslabs/aws-lambda-web-adapter/tree/main/examples/expressjs-zip) 準拠）:
+
+- Layer `LambdaAdapterLayerX86:28`、`Handler = run.sh`、`AWS_LAMBDA_EXEC_WRAPPER=/opt/bootstrap`、`PORT=8000`
+- readiness probe が計測を汚さないよう `AWS_LWA_READINESS_CHECK_PATH=/healthz` に分離し、
+  `/healthz` は `work()` を呼ばず即 200 を返す
+
+## 再現手順
+
+```bash
+# 依存: node, aws cli（認証済み）, terraform, zip
+
+# 1. ローカル基準（普通の HTTP server）
+./build.sh
+SLEEP_MS=5000 PORT=8000 node src/server.mjs &
+node driver/drive.mjs http://localhost:8000/ 10 "local"
+kill %1
+
+# 2. Lambda（concurrency=1 → 直列 ~50s）
+cd infra && terraform init
+terraform apply -auto-approve -var reserved_concurrency=1
+node ../driver/drive.mjs "$(terraform output -raw plain_url)" 10 "plain conc=1"
+node ../driver/drive.mjs "$(terraform output -raw lwa_url)"   10 "lwa conc=1"
+
+# 3. Lambda（concurrency=10 → 並列 ~5s）
+terraform apply -auto-approve -var reserved_concurrency=10
+node ../driver/drive.mjs "$(terraform output -raw plain_url)" 10 "plain conc=10"
+node ../driver/drive.mjs "$(terraform output -raw lwa_url)"   10 "lwa conc=10"
+
+# 4. 後片付け（Function URL は auth=NONE の公開エンドポイントなので必ず削除）
+terraform destroy -auto-approve -var reserved_concurrency=10
+```
+
+注意: Function URL を `authorization_type = NONE`（公開）で作る。URL を知る誰でも
+呼び出せるので、実験が終わったら `terraform destroy` で必ず削除する。
+
+## 補足: concurrency=1 で ~50s を出すための throttle 対応
+
+同期呼び出し（Function URL / RequestResponse）は concurrency 上限を超えた分を
+**キューせず 429 TooManyRequestsException で即返す**。10 並列を素で投げると
+1 件成功・9 件即エラーで終わり ~50s にならない。`driver/drive.mjs` は 429 を受けたら
+一定間隔でポーリング再試行し、空いた枠に順次入ることで直列 ~50s を再現している。

--- a/infra/aws/lambda-concurrency/build.sh
+++ b/infra/aws/lambda-concurrency/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+# System zip preserves the executable bit on run.sh, which the Web Adapter needs
+# to exec it. terraform's archive_file does not preserve file modes reliably.
+rm -rf dist
+mkdir -p dist
+chmod +x src/run.sh
+
+( cd src && zip -q -X ../dist/plain.zip lambda.mjs shared.mjs )
+( cd src && zip -q -X ../dist/lwa.zip server.mjs shared.mjs run.sh )
+
+echo "built:"
+echo "  dist/plain.zip -> $(unzip -Z1 dist/plain.zip | tr '\n' ' ')"
+echo "  dist/lwa.zip   -> $(unzip -Z1 dist/lwa.zip | tr '\n' ' ')"

--- a/infra/aws/lambda-concurrency/cold-start-and-reuse.md
+++ b/infra/aws/lambda-concurrency/cold-start-and-reuse.md
@@ -1,0 +1,125 @@
+# 実行環境の再利用とコールドスタート（調査メモ）
+
+[README.md](./README.md) の並列性実験で使ったのと同じ関数・ログを材料に、
+「2 回目以降の invocation はキャッシュに乗って速いのか」「そのキャッシュは
+何単位なのか」を調べたメモ。
+
+## 問い
+
+1. Lambda の起動は重い（JVM の Spring Boot 等）。2 回目以降の invocation は
+   初期化済みの状態を再利用して速くなるのか。
+2. その「キャッシュ」は何の単位で効くのか（実行環境ごとか、グローバルに共有か）。
+
+## 結論
+
+1. 速くなる。ただし「キャッシュ」ではなく**実行環境の凍結(freeze)と解凍(thaw)による再利用**。
+   handler の外（static 初期化 / Init フェーズ）で作った状態は、その実行環境が warm な間は
+   再初期化されない。
+2. 再利用の単位は**実行環境(env)ごと**。同時リクエストは別 env に振られるので env をまたいで
+   共有されない。しかも再利用は保証ではなくベストエフォート（"where possible"）。
+
+## 実測との対応（実行時間）
+
+README の実験（各リクエスト 5 秒 sleep / 10 並列 / ap-northeast-1 / nodejs22.x）で観測した値。
+
+| ランナー | reserved conc | 合計 | 異なる envId | 1env内 max inFlight |
+|---|---|---|---|---|
+| ローカル Node HTTP server | － | 5.04 s | 1 | 10 |
+| lambda-plain | 1 | 52.38 s | 1 | 1 |
+| lambda-plain | 10 | 5.49 s | 10 | 1 |
+| lambda-lwa | 1 | 52.40 s | 1 | 1 |
+| lambda-lwa | 10 | 5.54 s | 10 | 1 |
+
+コールド/ウォームの内訳（同じ実験の生ログから）:
+
+- 単発の疎通（コールド込み）: plain `http 200 in 5.53s` / lwa `5.71s`。
+  handler 本体は 5 秒 sleep なので、超過分の **約 0.5〜0.7 秒が Init（コールドスタート）**。
+- warm な各回の `durationMs` は一貫して **5006**（＝sleep 5000 + 誤差、初期化コスト 0）。
+- concurrency=1 の env `f27830b8` は全 run を通じて `invocations` が 1→11→12 と増えたが、
+  `durationMs` は毎回 5006。→ **同じ env が再利用され、2 回目以降は初期化を払っていない**。
+- concurrency=10 の合計 5.49s のうち超過分 約 0.5s は、**新規 10 env が同時にコールドスタート**した分。
+
+我々の Node 関数は Init が約 0.5 秒と軽いのでこの差は小さいが、**Spring Boot ならこの部分が
+数秒**になる。そしてそれを払うのはコールドの 1 回だけで、warm な 2 回目以降は handler 実行だけになる。
+
+## 仕組み: なぜ 2 回目が速いか
+
+Lambda のライフサイクルは Init フェーズと Invoke フェーズに分かれる。
+
+- Init フェーズ: ランタイム起動 + handler の外側の初期化コード（static initialization）を実行。
+  JVM 起動・Spring ApplicationContext 構築・DB コネクション確立はここでやるのが定石。
+- Invoke フェーズ: handler メソッドの実行。invocation ごとに毎回走る。
+
+呼び出し後、env は凍結され、次の呼び出しで解凍して再利用される。このとき Init は再実行されない。
+
+> "During this entire process, this execution environment is busy and cannot process other
+> requests. When Lambda finishes processing the first request, this execution environment can
+> then process additional requests for the same function. **For subsequent requests, Lambda
+> doesn't need to re-initialize the environment.**"
+> — [Understanding Lambda function scaling](https://docs.aws.amazon.com/lambda/latest/dg/lambda-concurrency.html#understanding-concurrency)
+
+> "When the function is invoked again, Lambda thaws the environment for reuse. **Reusing the
+> execution environment has the following implications: Objects declared outside of the
+> function's handler method remain initialized** ... if your Lambda function establishes a
+> database connection, instead of reestablishing the connection, the original connection is
+> used in subsequent invocations."
+> — [execution environment lifecycle](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html#runtimes-lifecycle-shutdown)
+
+## 「キャッシュは env 単位」の根拠
+
+単一の文で「per-env cache」とは書かれていない。次の 3 記述の合成で導ける。
+
+(A) 同じ env の再利用で初期化を省く（上記引用）。
+
+(B) 同時リクエストは別 env に振られる:
+
+> "**For each concurrent request, Lambda provisions a separate instance of your execution
+> environment.**"
+> — [同上 concurrency doc](https://docs.aws.amazon.com/lambda/latest/dg/lambda-concurrency.html#understanding-concurrency)
+
+(C) 単一 invocation 前提で、グローバル state に依存するな（＝実質 env ローカルの明文）:
+
+> "For standard Lambda functions, **you should assume that the environment exists only for a
+> single invocation.** ... It should not rely on any existing data structures or temporary
+> files, or any internal state that would be managed by multiple invocations."
+
+> "To initialize database connections and libraries, or load state, you can take advantage of
+> static initialization. **Since execution environments are reused where possible** to improve
+> performance, you can amortize the time taken to initialize these resources over multiple
+> invocations. However, **you should not store any variables or data used in the function
+> within this global scope.**"
+> — [Implement statelessness in functions](https://docs.aws.amazon.com/lambda/latest/dg/concepts-application-design.html#statelessness-functions)
+
+実験でグローバルの `ENV_ID`(UUID) が env ごとに別値・env 内で一定だったのは、この
+「グローバル state は env ローカル」の実演。JVM/Spring の初期化済みコンテキストも同じ扱い。
+
+補足: concurrency=10 で全 env の Node プロセス PID が同値だった（plain=2, lwa=5）。各 env は
+独立した microVM でまっさらな名前空間から起動するため PID が被り、**PID は env 識別子にならない**。
+
+## スケールアウト時の注意（並列性の話と直結）
+
+キャッシュは env 単位なので、バーストで env が増えるとその**新規 env はそれぞれコールドスタート**する。
+
+- concurrency=10 の実験で envId が 10 個に増えたとき、10 env は各々初期化を払っている。
+- warm が速いのは「トラフィックが既存 env の再利用に収まっている間」だけ。
+- 保証ではなくベストエフォート。アイドルが続く/数時間ごとに env は破棄され、その後はまたコールド。
+
+## JVM / Spring のコールドを縮める手段
+
+1. **SnapStart（Java など、追加課金なし）**: 初期化済み実行環境のスナップショットから復元する。
+   JVM 起動 + Spring コンテキスト構築ごと凍結・復元するので Spring Boot のコールドに最も効く。
+   > "Lambda saves a snapshot of the memory and disk state of the initialized execution
+   > environment, persists the encrypted snapshot, and caches it for low-latency access."
+   > — [execution environment lifecycle（Init/SnapStart）](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html#runtimes-lifecycle-ib)
+
+   注意: スナップショットに状態が焼き付く。乱数シードの一意性や、コネクション再確立の
+   runtime hook（after-restore）を要検討。
+2. **Provisioned Concurrency（課金あり）**: N 個の env を事前初期化して常備。コールド自体を出さない。
+3. **初期化を軽くする**: 使う依存だけ import、遅延ロード等。Init は 10 秒制限がある点も留意。
+
+## 参考リンク
+
+- Understanding Lambda function scaling: https://docs.aws.amazon.com/lambda/latest/dg/lambda-concurrency.html
+- Understanding the Lambda execution environment lifecycle: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html
+- Designing Lambda applications（statelessness）: https://docs.aws.amazon.com/lambda/latest/dg/concepts-application-design.html
+- Lambda SnapStart: https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html

--- a/infra/aws/lambda-concurrency/driver/drive.mjs
+++ b/infra/aws/lambda-concurrency/driver/drive.mjs
@@ -1,0 +1,57 @@
+// Fires N requests in parallel and aggregates the responses by envId.
+//
+// Usage: node driver/drive.mjs <baseUrl> [n=10] [label]
+//
+// A Function URL throttled by reserved concurrency returns HTTP 429. Lambda does
+// not queue synchronous invocations, so the driver polls on 429 until a slot frees;
+// this reproduces the serialized (~n * sleep) wall clock for concurrency = 1.
+const [, , baseUrl, nArg, labelArg] = process.argv;
+
+if (!baseUrl) {
+  console.error('usage: node driver/drive.mjs <baseUrl> [n=10] [label]');
+  process.exit(1);
+}
+
+const N = Number(nArg ?? 10);
+const LABEL = labelArg ?? baseUrl;
+const POLL_MS = 500;
+
+async function fire(i) {
+  const startedAt = Date.now();
+  let attempts = 0;
+  for (;;) {
+    attempts += 1;
+    const res = await fetch(baseUrl, { headers: { 'x-req': String(i) } });
+    if (res.status === 429) {
+      await new Promise((r) => setTimeout(r, POLL_MS));
+      continue;
+    }
+    const body = await res.json();
+    return { i, status: res.status, throttleWaits: attempts - 1, roundtripMs: Date.now() - startedAt, ...body };
+  }
+}
+
+const startedAt = Date.now();
+const results = await Promise.all(Array.from({ length: N }, (_, i) => fire(i)));
+const totalMs = Date.now() - startedAt;
+
+const byEnv = new Map();
+for (const r of results) {
+  const list = byEnv.get(r.envId) ?? [];
+  list.push(r);
+  byEnv.set(r.envId, list);
+}
+
+const maxInFlight = Math.max(...results.map((r) => r.maxInFlight));
+
+console.log(`\n=== ${LABEL} ===`);
+console.log(`requests           : ${N}`);
+console.log(`total wall clock   : ${(totalMs / 1000).toFixed(2)} s`);
+console.log(`distinct envIds    : ${byEnv.size}`);
+console.log(`max inFlight (any) : ${maxInFlight}`);
+console.log('per env:');
+for (const [envId, list] of byEnv) {
+  const maxIf = Math.max(...list.map((r) => r.maxInFlight));
+  const inv = Math.max(...list.map((r) => r.invocations));
+  console.log(`  ${envId.slice(0, 8)}  handled=${list.length}  maxInFlight=${maxIf}  invocations=${inv}  pid=${list[0].pid}`);
+}

--- a/infra/aws/lambda-concurrency/infra/main.tf
+++ b/infra/aws/lambda-concurrency/infra/main.tf
@@ -1,0 +1,110 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda" {
+  name               = "lambda-concurrency-exp"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "logs" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+locals {
+  plain_zip = "${path.module}/../dist/plain.zip"
+  lwa_zip   = "${path.module}/../dist/lwa.zip"
+  # Public Web Adapter layer, latest version published in this region.
+  lwa_layer = "arn:aws:lambda:${var.region}:753240598075:layer:LambdaAdapterLayerX86:28"
+}
+
+resource "aws_lambda_function" "plain" {
+  function_name                  = "concurrency-plain"
+  role                           = aws_iam_role.lambda.arn
+  runtime                        = "nodejs22.x"
+  handler                        = "lambda.handler"
+  architectures                  = ["x86_64"]
+  filename                       = local.plain_zip
+  source_code_hash               = filebase64sha256(local.plain_zip)
+  timeout                        = 30
+  memory_size                    = 512
+  reserved_concurrent_executions = var.reserved_concurrency
+
+  environment {
+    variables = {
+      SLEEP_MS = tostring(var.sleep_ms)
+    }
+  }
+}
+
+resource "aws_lambda_function" "lwa" {
+  function_name                  = "concurrency-lwa"
+  role                           = aws_iam_role.lambda.arn
+  runtime                        = "nodejs22.x"
+  handler                        = "run.sh"
+  architectures                  = ["x86_64"]
+  filename                       = local.lwa_zip
+  source_code_hash               = filebase64sha256(local.lwa_zip)
+  timeout                        = 30
+  memory_size                    = 512
+  reserved_concurrent_executions = var.reserved_concurrency
+  layers                         = [local.lwa_layer]
+
+  environment {
+    variables = {
+      AWS_LAMBDA_EXEC_WRAPPER      = "/opt/bootstrap"
+      PORT                         = "8000"
+      AWS_LWA_READINESS_CHECK_PATH = "/healthz"
+      RUST_LOG                     = "info"
+      SLEEP_MS                     = tostring(var.sleep_ms)
+    }
+  }
+}
+
+resource "aws_lambda_function_url" "plain" {
+  function_name      = aws_lambda_function.plain.function_name
+  authorization_type = "NONE"
+}
+
+resource "aws_lambda_function_url" "lwa" {
+  function_name      = aws_lambda_function.lwa.function_name
+  authorization_type = "NONE"
+}
+
+# authorization_type = NONE still needs a resource policy granting public invoke.
+resource "aws_lambda_permission" "plain_url" {
+  statement_id           = "AllowPublicFunctionUrl"
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = aws_lambda_function.plain.function_name
+  principal              = "*"
+  function_url_auth_type = "NONE"
+}
+
+resource "aws_lambda_permission" "lwa_url" {
+  statement_id           = "AllowPublicFunctionUrl"
+  action                 = "lambda:InvokeFunctionUrl"
+  function_name          = aws_lambda_function.lwa.function_name
+  principal              = "*"
+  function_url_auth_type = "NONE"
+}

--- a/infra/aws/lambda-concurrency/infra/outputs.tf
+++ b/infra/aws/lambda-concurrency/infra/outputs.tf
@@ -1,0 +1,7 @@
+output "plain_url" {
+  value = aws_lambda_function_url.plain.function_url
+}
+
+output "lwa_url" {
+  value = aws_lambda_function_url.lwa.function_url
+}

--- a/infra/aws/lambda-concurrency/infra/variables.tf
+++ b/infra/aws/lambda-concurrency/infra/variables.tf
@@ -1,0 +1,16 @@
+variable "region" {
+  type    = string
+  default = "ap-northeast-1"
+}
+
+# Applied to both functions. Flip between 1 (serialized) and 10 (parallel) to
+# observe how the parallelism unit changes.
+variable "reserved_concurrency" {
+  type    = number
+  default = 1
+}
+
+variable "sleep_ms" {
+  type    = number
+  default = 5000
+}

--- a/infra/aws/lambda-concurrency/src/lambda.mjs
+++ b/infra/aws/lambda-concurrency/src/lambda.mjs
@@ -1,0 +1,13 @@
+import { work } from './shared.mjs';
+
+const SLEEP_MS = Number(process.env.SLEEP_MS ?? 5000);
+
+// Plain Lambda handler behind a Function URL (payload format 2.0).
+export const handler = async () => {
+  const result = await work(SLEEP_MS);
+  return {
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ runner: 'lambda-plain', ...result }),
+  };
+};

--- a/infra/aws/lambda-concurrency/src/run.sh
+++ b/infra/aws/lambda-concurrency/src/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Web Adapter startup command (Handler = run.sh). Starts the HTTP server that the
+# adapter forwards each invocation to. exec so the server receives Lambda's signals.
+exec node server.mjs

--- a/infra/aws/lambda-concurrency/src/server.mjs
+++ b/infra/aws/lambda-concurrency/src/server.mjs
@@ -1,0 +1,24 @@
+import { createServer } from 'node:http';
+import { work } from './shared.mjs';
+
+// Shared by two runners: run locally with `node src/server.mjs`, and inside
+// Lambda through the Web Adapter. The code is identical; only the substrate differs.
+const PORT = Number(process.env.PORT ?? process.env.AWS_LWA_PORT ?? 8000);
+const SLEEP_MS = Number(process.env.SLEEP_MS ?? 5000);
+
+// The Web Adapter readiness probe must not run work(), or it would pollute the
+// invocation/inFlight counters. It is routed to /healthz via AWS_LWA_READINESS_CHECK_PATH.
+const server = createServer(async (req, res) => {
+  if (req.url === '/healthz') {
+    res.writeHead(200, { 'content-type': 'text/plain' });
+    res.end('ok');
+    return;
+  }
+  const result = await work(SLEEP_MS);
+  res.writeHead(200, { 'content-type': 'application/json' });
+  res.end(JSON.stringify({ runner: 'server', ...result }));
+});
+
+server.listen(PORT, () => {
+  console.log(`listening on ${PORT} (sleepMs=${SLEEP_MS})`);
+});

--- a/infra/aws/lambda-concurrency/src/shared.mjs
+++ b/infra/aws/lambda-concurrency/src/shared.mjs
@@ -1,0 +1,38 @@
+import { randomUUID } from 'node:crypto';
+
+// One id per execution environment / OS process. Assigned once at module init
+// (cold start for Lambda, process start locally) and reused across warm
+// invocations, so distinct envId values equal distinct execution environments.
+export const ENV_ID = randomUUID();
+
+// Module-scope counters survive across invocations while the environment is warm.
+// inFlight is the number of requests currently inside work() at the same time.
+let inFlight = 0;
+let maxInFlight = 0;
+let invocations = 0;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Simulates an I/O-bound request: increment the concurrency gauge, await, decrement.
+// A runtime that multiplexes requests during the await (a normal HTTP server) will
+// observe inFlight > 1; one that serializes per environment (Lambda) stays at 1.
+export async function work(sleepMs) {
+  invocations += 1;
+  inFlight += 1;
+  if (inFlight > maxInFlight) maxInFlight = inFlight;
+  const inFlightAtEntry = inFlight;
+  const startedAt = Date.now();
+  try {
+    await sleep(sleepMs);
+    return {
+      envId: ENV_ID,
+      pid: process.pid,
+      inFlightAtEntry,
+      maxInFlight,
+      invocations,
+      durationMs: Date.now() - startedAt,
+    };
+  } finally {
+    inFlight -= 1;
+  }
+}


### PR DESCRIPTION
## 何を

Lambda の並列性の単位を実測で確かめる til 実験一式を追加。

問い: Lambda は「I/O wait 中に同じ実行環境で別リクエストを処理する」のか、それとも
「並列化は execution environment の増加でしか起きない」のか。Web Adapter を入れると変わるのか。

## 構成

同一ロジック `work = await sleep(5s)` を 3 ランナーで共有する。

- ローカル Node HTTP server（イベントループ多重化の基準）
- lambda-plain: 普通の async handler + Function URL
- lambda-lwa: ローカルと同一の `server.mjs` を Web Adapter 経由で実行 + Function URL

terraform で 2 関数を作り、reserved concurrency を変数で 1 / 10 に切り替えて driver から 10 並列で叩く。

## 実測結果（ap-northeast-1 / nodejs22.x / 各 5 秒 sleep / 10 並列）

- ローカル Node server: 5.04s / envId 1 / 1 env 内 maxInFlight 10
- lambda-plain conc=1: 52.38s / envId 1 / maxInFlight 1
- lambda-plain conc=10: 5.49s / envId 10 / maxInFlight 1
- lambda-lwa conc=1: 52.40s / envId 1 / maxInFlight 1
- lambda-lwa conc=10: 5.54s / envId 10 / maxInFlight 1

結論: デフォルトの Lambda では 1 実行環境は 1 invocation を処理中に他を受けない。並列化は
実行環境の増加でしか起きない。Web Adapter を入れても不変（多重同時処理は Lambda Managed
Instances という別機能の領分）。公式ドキュメントの一次引用を README / cold-start-and-reuse.md に記載。

cold-start-and-reuse.md では「2 回目以降が速い理由（実行環境の freeze/thaw 再利用）」「キャッシュが
env 単位である根拠」「SnapStart 等のコールド緩和」を実行時間の実測と合わせて整理。

## 検証

- 実 AWS にデプロイして上記を実測。取得後 `terraform destroy` で全 8 リソース削除し、
  `aws lambda list-functions` で `concurrency-*` が空であることを確認済み。
- 秘匿情報の混入なしを確認（自アカウント ID・実 Function URL・資格情報いずれも source に無し）。
  terraform state / dist / .terraform は `.gitignore` 済みで未追跡。
- 公開 AWS アカウント `753240598075`（Web Adapter 層のホスト）は非秘匿のため main.tf に残置。

## 注意

Function URL は `authorization_type = NONE`（公開）で作る設計。実験後は必ず
`terraform destroy` で削除すること（README に明記）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
